### PR TITLE
added some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,55 @@
+# ansible
+secrets.yml
 inventory.yml
+
+# editor
+.DS_Store
+**/.DS_Store
+.AppleDouble
+.LSOverride
+.vscode
+**/.vscode
+.idea
+**/.idea
+*.iml
+*.ipr
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# token
+.token.env
+*.token.env
+*.token.env.*
+*.env
+*.token
+env
+.env

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -43,5 +43,8 @@ all:
     user_dir: "/home/{{ ansible_user }}"
     path: "/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_dir }}/go/bin:{{ user_dir }}/.cargo/bin"
 
+    aleo_service_path: "/etc/systemd/system/aleo.service"
+    aleo_script_path: "{{ working_dir }}/aleo.sh"
+
     # github
     github_repo: https://github.com/AleoNet/snarkOS.git

--- a/roles/node_configure/tasks/main.yml
+++ b/roles/node_configure/tasks/main.yml
@@ -1,12 +1,26 @@
 ---
-- name: make working directory
+- name: Define script path variable
+  vars:
+    aleo_script_path: "{{ working_dir }}/aleo.sh"
+
+- name: Make working directory
   file:
     path: "{{ working_dir }}"
     state: directory
     mode: "0755"
 
-- name: copy aleo.sh script
+- name: Copy aleo.sh script
   template:
     src: aleo.sh.j2
-    dest: "{{ working_dir }}/aleo.sh"
-    mode: 0755
+    dest: "{{ aleo_script_path }}"
+    mode: "0755"
+
+- name: Verify aleo.sh script file is created
+  stat:
+    path: "{{ aleo_script_path }}"
+  register: aleo_script
+
+- name: Fail if aleo.sh script was not created
+  fail:
+    msg: "aleo.sh script file was not created successfully!"
+  when: not aleo_script.stat.exists

--- a/roles/node_configure/tasks/main.yml
+++ b/roles/node_configure/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Define script path variable
-  vars:
-    aleo_script_path: "{{ working_dir }}/aleo.sh"
-
 - name: Make working directory
   file:
     path: "{{ working_dir }}"

--- a/roles/node_launch/tasks/main.yml
+++ b/roles/node_launch/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: define variables
-  vars:
-    aleo_service_path: "/etc/systemd/system/aleo.service"
-
 - name: copy service file
   become: true
   template:

--- a/roles/node_launch/tasks/main.yml
+++ b/roles/node_launch/tasks/main.yml
@@ -1,12 +1,26 @@
 ---
+- name: define variables
+  vars:
+    aleo_service_path: "/etc/systemd/system/aleo.service"
+
 - name: copy service file
   become: true
   template:
     src: aleo.service.j2
-    dest: /etc/systemd/system/aleo.service
+    dest: "{{ aleo_service_path }}"
     owner: root
     group: root
     mode: "0644"
+
+- name: verify aleo.service file exists
+  stat:
+    path: "{{ aleo_service_path }}"
+  register: aleo_service
+
+- name: fail if aleo.service file was not created
+  fail:
+    msg: "aleo.service file was not created successfully!"
+  when: not aleo_service.stat.exists
 
 - name: start service
   become: true

--- a/roles/node_launch/templates/aleo.service.j2
+++ b/roles/node_launch/templates/aleo.service.j2
@@ -9,8 +9,18 @@ WorkingDirectory={{ working_dir }}
 Environment="PATH={{ path }}"
 ExecStart=/bin/bash {{ working_dir }}/aleo.sh
 ExecStop=/bin/kill -s INT ${MAINPID}
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitInterval=60
+StartLimitBurst=5
+
+# Logging
+StandardOutput=append:/var/log/aleo.log
+StandardError=append:/var/log/aleo.log
+
+# Resource limits
+TimeoutStopSec=30
+
 # Systemd scheduling
 CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=20


### PR DESCRIPTION
Made some improvements

Changes:
☑ Code improvement

- modified:   .gitignore:  added more files to be ignored, the most annoying one is editor related files
- modified:   roles/node_configure/tasks/main.yml: added logic to check `aleo.sh` script file existence and also added `aleo_script_path` variable to declare the path to the script file, by doing so, we can use the variable path 
- modified:   roles/node_launch/tasks/main.yml: added logic to check `aleo.service` file existence and added service file path variable
- modified:   roles/node_launch/templates/aleo.service.j2: 
    - currently logs are send to `/dev/null` which is in Linux work as the block hole and is [discarded immediately](https://man7.org/linux/man-pages/man4/null.4.html). After the update logs are captured and saved to `/var/log/aleo.log`
    - added timeout for clean(graceful) shutdown, before this the service was used to send only `SIGINT` on stop
    - `Restart=always` ensures that service restarts on all failures. `StartLimitInterval=60` and `StartLimitBurst=5` limit restart to 5 attempts per minute which basically prevents the restart loop.